### PR TITLE
Increment version to 0.1.3 and support minSdkVersion 21

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 ext {
-    version = "0.1.2"
+    version = "0.1.3"
 }
 
 android {
@@ -16,7 +16,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
         versionName project.ext.version


### PR DESCRIPTION
This appears to just work by changing the minSdkVersion. I'm going to publish a new version of the library from this branch to unblock Hipcamp, then we can figure out how to make this change properly.