### PR TITLE
Remove references to Firebase KTX and use only Java-compatible Firebase dependencies

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -60,9 +60,11 @@ dependencies {
     implementation 'com.flaviofaria:kenburnsview:1.0.7'
 
     // For testing the optional firebase integration
+    // Compile against Java versions instead of KTX versions because not all clients will have
+    // Kotlin/KTX on dependency path
     implementation platform('com.google.firebase:firebase-bom:28.2.0')
-    implementation 'com.google.firebase:firebase-analytics-ktx'
-    implementation 'com.google.firebase:firebase-config-ktx'
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.firebase:firebase-config'
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 ext {
-    version = "1.0.0"
+    version = "1.0.1"
     PUBLISH_GROUP_ID = 'ai.promoted'
     PUBLISH_VERSION = version
     PUBLISH_ARTIFACT_ID = 'android-metrics-sdk'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -82,9 +82,11 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
 
     // Optional Promoted add-ons
+    // Compile against Java versions instead of KTX versions because not all clients will have
+    // Kotlin/KTX on dependency path
     compileOnly platform('com.google.firebase:firebase-bom:28.1.0')
-    compileOnly 'com.google.firebase:firebase-analytics-ktx'
-    compileOnly 'com.google.firebase:firebase-config-ktx'
+    compileOnly 'com.google.firebase:firebase-analytics'
+    compileOnly 'com.google.firebase:firebase-config'
 
     testImplementation 'junit:junit:4.+'
     testImplementation "io.mockk:mockk:1.11.0"
@@ -92,8 +94,8 @@ dependencies {
 
     // Make sure the optional Promoted add-ons are included when tests run
     testImplementation platform('com.google.firebase:firebase-bom:28.1.0')
-    testImplementation 'com.google.firebase:firebase-analytics-ktx'
-    testImplementation 'com.google.firebase:firebase-config-ktx'
+    testImplementation 'com.google.firebase:firebase-analytics'
+    testImplementation 'com.google.firebase:firebase-config'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/library/src/main/java/ai/promoted/config/FirebaseRemoteConfigService.kt
+++ b/library/src/main/java/ai/promoted/config/FirebaseRemoteConfigService.kt
@@ -3,7 +3,6 @@ package ai.promoted.config
 import ai.promoted.ClientConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue
-import com.google.firebase.remoteconfig.ktx.get
 
 private const val LOGGING_ENABLED = "ai_promoted_logging_enabled"
 private const val API_URL = "ai_promoted_metrics_logging_url"
@@ -25,14 +24,14 @@ internal class FirebaseRemoteConfigService(
     override val latestRemoteConfig: RemoteConfig
         get() {
             val loggingEnabled =
-                firebaseRemoteConfig[LOGGING_ENABLED].asBooleanOrNull()
+                firebaseRemoteConfig.getValue(LOGGING_ENABLED).asBooleanOrNull()
             val apiUrl =
-                firebaseRemoteConfig[API_URL].asNonEmptyStringOrNull()
+                firebaseRemoteConfig.getValue(API_URL).asNonEmptyStringOrNull()
             val apiKey =
-                firebaseRemoteConfig[API_KEY].asNonEmptyStringOrNull()
+                firebaseRemoteConfig.getValue(API_KEY).asNonEmptyStringOrNull()
             val wireFormat = firebaseRemoteConfig.getWireFormatOrNull()
             val flushInterval =
-                firebaseRemoteConfig[FLUSH_INTERVAL].asLongOrNull()
+                firebaseRemoteConfig.getValue(FLUSH_INTERVAL).asLongOrNull()
             val xrayEnabled = firebaseRemoteConfig.getXrayEnabledOrNull()
 
             return RemoteConfig(
@@ -64,7 +63,7 @@ internal class FirebaseRemoteConfigService(
      * will fall back to null so that the compiled [ClientConfig.metricsLoggingWireFormat] is used.
      */
     private fun FirebaseRemoteConfig.getWireFormatOrNull(): ClientConfig.MetricsLoggingWireFormat? =
-        when (this[WIRE_FORMAT].asNonEmptyStringOrNull()) {
+        when (this.getValue(WIRE_FORMAT).asNonEmptyStringOrNull()) {
             "json" -> ClientConfig.MetricsLoggingWireFormat.Json
             "binary" -> ClientConfig.MetricsLoggingWireFormat.Binary
             else -> null
@@ -76,7 +75,7 @@ internal class FirebaseRemoteConfigService(
      * of the enums (or an empty, or a null string) will return null.
      */
     private fun FirebaseRemoteConfig.getXrayEnabledOrNull(): Boolean? =
-        when (this[XRAY_LEVEL].asNonEmptyStringOrNull()) {
+        when (this.getValue(XRAY_LEVEL).asNonEmptyStringOrNull()) {
             "none" -> false
             "error",
             "warning",


### PR DESCRIPTION
### Issue
Clients that use Firebase, but have Java-only projects were experiencing a runtime crash due to our internal Firebase code expecting a `ktx` form of the Firebase dependencies. Since the project was Java-only, the `ktx` form of the Firebase dependencies was not on the classpath and caused a crash.

### Resolution
Remove all references to `ktx` versions of Firebase dependencies and only compile against Java-compatible versions.