### PR TITLE
PRO-1990 - Add ClientInfo message to LogRequest

### DIFF
--- a/library/src/main/java/ai/promoted/metrics/usecases/FinalizeLogsUseCase.kt
+++ b/library/src/main/java/ai/promoted/metrics/usecases/FinalizeLogsUseCase.kt
@@ -66,6 +66,7 @@ internal class FinalizeLogsUseCase(
 
     private fun prepareLogs(logMessages: List<Message>): LogRequest {
         val logRequestBuilder = LogRequest.newBuilder()
+        logRequestBuilder.clientInfo = createClientInfo()
         logRequestBuilder.userInfo = createUserInfoMessage(
             userId = trackUserUseCase.currentOrNullUserId,
             logUserId = trackUserUseCase.currentOrNullLogUserId

--- a/library/src/main/java/ai/promoted/metrics/usecases/MessageCreation.kt
+++ b/library/src/main/java/ai/promoted/metrics/usecases/MessageCreation.kt
@@ -15,6 +15,7 @@ import ai.promoted.metrics.InternalImpressionData
 import ai.promoted.platform.Clock
 import ai.promoted.platform.DeviceInfoProvider
 import ai.promoted.platform.PromotedAiLocale
+import ai.promoted.proto.common.ClientInfo
 import ai.promoted.proto.common.Device
 import ai.promoted.proto.common.Properties
 import ai.promoted.proto.common.Screen
@@ -202,5 +203,14 @@ internal fun createUserInfoMessage(userId: String?, logUserId: String?) =
         .apply {
             userId?.let { setUserId(it) }
             logUserId?.let { setLogUserId(it) }
+        }
+        .build()
+
+internal fun createClientInfo() =
+    ClientInfo
+        .newBuilder()
+        .apply {
+            clientType = ClientInfo.ClientType.PLATFORM_CLIENT
+            trafficType = ClientInfo.TrafficType.PRODUCTION
         }
         .build()

--- a/library/src/test/java/ai/promoted/metrics/usecases/FinalizeLogsUseCaseTest.kt
+++ b/library/src/test/java/ai/promoted/metrics/usecases/FinalizeLogsUseCaseTest.kt
@@ -3,6 +3,7 @@ package ai.promoted.metrics.usecases
 import ai.promoted.ClientConfig
 import ai.promoted.mockkRelaxedUnit
 import ai.promoted.platform.DeviceInfoProvider
+import ai.promoted.proto.common.ClientInfo
 import ai.promoted.proto.delivery.Insertion
 import ai.promoted.proto.delivery.Request
 import ai.promoted.proto.event.Action
@@ -55,6 +56,17 @@ class FinalizeLogsUseCaseTest {
         val deserializedData = LogRequest.parseFrom(request.bodyData)
         assertThat(deserializedData.userInfo.userId, equalTo(testUserId))
         assertThat(deserializedData.userInfo.logUserId, equalTo(testLogUserId))
+    }
+
+    @Test
+    fun `Should set client info on final logs`() {
+        // When logs finalized
+        val request = useCase.finalizeLogs(emptyList())
+
+        // Then the serialized data contains the correct client info
+        val deserializedData = LogRequest.parseFrom(request.bodyData)
+        assertThat(deserializedData.clientInfo.clientType, equalTo(ClientInfo.ClientType.PLATFORM_CLIENT))
+        assertThat(deserializedData.clientInfo.trafficType, equalTo(ClientInfo.TrafficType.PRODUCTION))
     }
 
     @Test


### PR DESCRIPTION
This PR adds the `ClientInfo` message to `LogRequest`.