### PR TITLE
PRO-836 - Don't log User records if both userId & logUserId are blank

### DIFF
--- a/library/src/main/java/ai/promoted/metrics/usecases/MessageCreation.kt
+++ b/library/src/main/java/ai/promoted/metrics/usecases/MessageCreation.kt
@@ -44,7 +44,7 @@ internal fun createTimingMessage(time: Long) =
         .setClientLogTimestamp(time)
         .build()
 
-internal fun createUserMessage(clock: Clock, userId: String?, logUserId: String?) =
+internal fun createUserMessage(clock: Clock, userId: String, logUserId: String) =
     User
         .newBuilder()
         .setTiming(createTimingMessage(clock))

--- a/library/src/main/java/ai/promoted/metrics/usecases/TrackUserUseCase.kt
+++ b/library/src/main/java/ai/promoted/metrics/usecases/TrackUserUseCase.kt
@@ -55,11 +55,10 @@ internal class TrackUserUseCase(
         logUser(logger, "", logUserId)
     }
 
-    private fun logUser(logger: MetricsLogger, userId: String, logUserId: String){
+    private fun logUser(logger: MetricsLogger, userId: String, logUserId: String) {
         // No need to logUser if there are no IDs
-        if(userId.isBlank() && logUserId.isBlank()) return
+        if (userId.isBlank() && logUserId.isBlank()) return
 
         logger.enqueueMessage(createUserMessage(clock, userId, logUserId))
     }
-
 }

--- a/library/src/main/java/ai/promoted/metrics/usecases/TrackUserUseCase.kt
+++ b/library/src/main/java/ai/promoted/metrics/usecases/TrackUserUseCase.kt
@@ -17,8 +17,7 @@ internal class TrackUserUseCase(
     val currentOrNullUserId: String?
         get() {
             val currentUserId = currentUserIdsUseCase.currentUserId
-            return if (currentUserId.isEmpty()) null
-            else currentUserId
+            return currentUserId.ifEmpty { null }
         }
 
     val currentLogUserId: String
@@ -27,15 +26,13 @@ internal class TrackUserUseCase(
     val currentOrPendingLogUserId: String
         get() {
             val currentLogUserId = this.currentLogUserId
-            return if (currentLogUserId.isEmpty()) logUserAncestorId.currentOrPendingValue
-            else currentLogUserId
+            return currentLogUserId.ifEmpty { logUserAncestorId.currentOrPendingValue }
         }
 
     val currentOrNullLogUserId: String?
         get() {
             val currentLogUserId = this.currentLogUserId
-            return if (currentLogUserId.isEmpty()) null
-            else currentLogUserId
+            return currentLogUserId.ifEmpty { null }
         }
 
     fun setUserId(logger: MetricsLogger, userId: String) = xray.monitored {
@@ -58,6 +55,11 @@ internal class TrackUserUseCase(
         logUser(logger, "", logUserId)
     }
 
-    private fun logUser(logger: MetricsLogger, userId: String, logUserId: String) =
+    private fun logUser(logger: MetricsLogger, userId: String, logUserId: String){
+        // No need to logUser if there are no IDs
+        if(userId.isBlank() && logUserId.isBlank()) return
+
         logger.enqueueMessage(createUserMessage(clock, userId, logUserId))
+    }
+
 }

--- a/library/src/test/java/ai/promoted/metrics/usecases/TrackActionUseCaseTest.kt
+++ b/library/src/test/java/ai/promoted/metrics/usecases/TrackActionUseCaseTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 
 class TrackActionUseCaseTest {
     private val randomUuid = "random-uuid"
-    private val logUserId = "log-user-id"
     private val testSessionId =
         AncestorId(UuidGenerator()).apply {
             override("session-id")
@@ -41,9 +40,7 @@ class TrackActionUseCaseTest {
             firstArg()
         }
     }
-    private val trackUserUseCase = mockk<TrackUserUseCase> {
-        every { currentLogUserId } returns logUserId
-    }
+
     private val useCase = TrackActionUseCase(
         clock = mockk { every { currentTimeMillis } returns 0L },
         logger = logger,

--- a/library/src/test/java/ai/promoted/metrics/usecases/TrackUserUseCaseTest.kt
+++ b/library/src/test/java/ai/promoted/metrics/usecases/TrackUserUseCaseTest.kt
@@ -1,0 +1,77 @@
+package ai.promoted.metrics.usecases
+
+import ai.promoted.metrics.MetricsLogger
+import ai.promoted.metrics.id.IdGenerator
+import ai.promoted.mockkRelaxedUnit
+import ai.promoted.proto.event.User
+import ai.promoted.xray.NoOpXray
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class TrackUserUseCaseTest {
+    private val mockIdGenerator: IdGenerator = mockkRelaxedUnit {
+        every { newId(any()) } returns "mock-generated-id"
+    }
+    private val mockCurrentUserIdsUseCase: CurrentUserIdsUseCase = mockkRelaxedUnit {
+        every { currentLogUserId } returns ""
+        every { currentUserId } returns ""
+    }
+    private val mockMetricsLogger: MetricsLogger = mockkRelaxedUnit()
+
+    private val useCase = TrackUserUseCase(
+        idGenerator = mockIdGenerator,
+        clock = mockk { every { currentTimeMillis } returns 0L },
+        currentUserIdsUseCase = mockCurrentUserIdsUseCase,
+        xray = NoOpXray()
+    )
+
+    @Test
+    fun `Should log user when new user ID set`() {
+        // Given no IDs set
+        every { mockCurrentUserIdsUseCase.currentLogUserId } returns ""
+        every { mockCurrentUserIdsUseCase.currentUserId } returns ""
+
+        // When set user ID
+        useCase.setUserId(mockMetricsLogger, userId = "test-id")
+
+        // Then log user is called with the user ID and
+        verify {
+            mockMetricsLogger.enqueueMessage(withArg {
+                assertThat(actual, instanceOf(User::class.java))
+                val userMessage = actual as User
+                assertThat(userMessage.userInfo, notNullValue())
+                val userInfoMessage = userMessage.userInfo!!
+                assertThat(userInfoMessage.userId, equalTo("test-id"))
+                assertThat(userInfoMessage.logUserId, equalTo("mock-generated-id"))
+            })
+        }
+    }
+
+    @Test
+    fun `Should not log user when existing user ID set`() {
+        // Given a current user ID has already been set
+        every { mockCurrentUserIdsUseCase.currentLogUserId } returns ""
+        every { mockCurrentUserIdsUseCase.currentUserId } returns "test-id"
+
+        // When set user ID
+        useCase.setUserId(mockMetricsLogger, userId = "test-id")
+
+        // Then log user is not called
+        verify(exactly = 0) { mockMetricsLogger.enqueueMessage(any<User>()) }
+    }
+
+    @Test
+    fun `Should not log user when logUserId is overridden with blank value`() {
+        // When override logUserId
+        useCase.overrideLogUserId(mockMetricsLogger, logUserId = "")
+
+        // Then log user is not called
+        verify(exactly = 0) { mockMetricsLogger.enqueueMessage(any<User>()) }
+    }
+}


### PR DESCRIPTION
This PR ensures that `logUser` is not called if both `userId` and `logUserId` are empty, thus avoiding a `User` record that only has a timestamp.